### PR TITLE
Add org_name parameter to default saving fct

### DIFF
--- a/R/downloadDs.R
+++ b/R/downloadDs.R
@@ -139,7 +139,7 @@ downloadDsServer <- function(id, formats, errorMessage = NULL, modalFunction = N
     ns <- session$ns
 
     # use default modalFunction to save file with dspin_urls if no modalFunction is specified
-    if(is.null(modalFunction) & !is.null(args$user_name)){
+    if(is.null(modalFunction)){
       modalFunction <- modalFunction_saveFile
     }
 

--- a/R/saveFile.R
+++ b/R/saveFile.R
@@ -38,6 +38,8 @@ modalFunction_saveFile <- function(...) {
   args_orig <- list(...)
   element <- args_orig$element
   user_name <- args_orig$user_name
+  org_name <- args_orig$org_name
+
   elementType <- args_orig$elementType
 
   if(!elementType %in% c("dsviz", "fringe", "drop")) stop("Element must be of type 'fringe', 'dsviz', or 'drop'.")
@@ -72,7 +74,6 @@ modalFunction_saveFile <- function(...) {
   # run dsviz(), fringe(), or drop()
   el <- do.call(elementType, element_params)
 
-  dspins_user_board_connect(folder = user_name, bucket_id = "user")
-  Sys.setlocale(locale = "en_US.UTF-8")
-  pins <- dspin_urls(element = el, user_name = user_name)
+  # save pin (if org_name is not NULL, saved in org_name, otherwise in user_name)
+  pins <- dspin_urls(element = el, user_name = user_name, org_name = org_name)
 }

--- a/inst/sample-downloadDs.R
+++ b/inst/sample-downloadDs.R
@@ -8,6 +8,7 @@ library(hgchmagic)
 
 
 user_name <- "test"
+org_name <- "brandon"
 
 
 ui <- panelsPage(panel(title = "Examples",
@@ -97,7 +98,8 @@ server <- function(input, output, session) {
                    element = reactive(element_dsviz()),
                    formats = c("html", "jpeg", "pdf", "png"),
                    elementType = "dsviz",
-                   user_name = user_name)
+                   user_name = user_name,
+                   org_name = org_name)
   })
 
   # use default modal function to save as pin


### PR DESCRIPTION
The function that is used to save files by default (when no `modalFunction` is passed to `downloadDsServer`) has now got an `org_name` parameter which is used when it is not null. 