### PR TITLE
Add packages to remotes AND imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,10 @@ Imports:
     pander,
     knitr,
     rio,
-    webshot
+    webshot,
+    dspins,
+    shinyinvoer,
+    homodatum
 Remotes: 
     datasketch/dspins,
     datasketch/shinyinvoer,


### PR DESCRIPTION
The previous PR had accidentally deleted imported DS packages from the `Import` section of the `DESCRIPTION` file. This commit fixes that.