### PR TITLE
Fixes to downloadDs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,13 +32,9 @@ Imports:
     knitr,
     rio,
     webshot,
-    dspins,
-    shinyinvoer,
-    homodatum
-Remotes: 
-    datasketch/dspins,
-    datasketch/shinyinvoer,
-    datasketch/homodatum
+    homodatum (>= 0.1.0),
+    shinyinvoer (>= 0.1),
+    dspins (>= 0.1.0)
 Suggests:
     rlang,
     testthat (>= 2.1.0)
@@ -46,3 +42,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.1
+Remotes:  
+    datasketch/homodatum,
+    datasketch/shinyinvoer,
+    datasketch/dspins

--- a/R/saveFile.R
+++ b/R/saveFile.R
@@ -78,9 +78,9 @@ modalFunction_saveFile <- function(...) {
 
   # add namespace to dsviz(), fringe(), or drop() function
   element_function_ns <- "dspins::"
-  if(elementType == "fringe") element_function_ns <- "homodatum::"
+  if(type == "fringe") element_function_ns <- "homodatum::"
 
-  element_function <- paste0(element_function_ns, elementType)
+  element_function <- paste0(element_function_ns, type)
 
   # run dsviz(), fringe(), or drop() with namespace
   el <- do.call(getfun(element_function), element_params)

--- a/R/saveFile.R
+++ b/R/saveFile.R
@@ -37,38 +37,36 @@ modalFunction_saveFile <- function(...) {
 
   args_orig <- list(...)
   element <- args_orig$element
+  type <- args_orig$type
   user_name <- args_orig$user_name
   org_name <- args_orig$org_name
+  bucket_id <- args_orig$bucket_id
 
-  elementType <- args_orig$elementType
+  if(is.null(element)) stop("Need element to save.")
+  if(is.null(type)) stop("Need type to save file.")
+  if(is.null(user_name) & is.null(org_name)) stop("Need user_name or org_name to save file.")
+  if(is.null(bucket_id)) bucket_id <- "user"
 
-  if(!elementType %in% c("dsviz", "fringe", "drop")) stop("Element must be of type 'fringe', 'dsviz', or 'drop'.")
+  if(!type %in% c("dsviz", "fringe", "drop")) stop("Element must be of type 'fringe', 'dsviz', or 'drop'.")
 
   element <- dsmodules:::eval_reactives(element)
   user_name <- dsmodules:::eval_reactives(user_name)
-
-  # extract string of updateTextInput field that needs to be updated if name is empty
-  name_field <- names(args_orig)[grepl('name$',names(args_orig))]
 
   # remove empty string arguments
   args <- args_orig[args_orig != ""]
 
   # extract input field names from args
   names(args) <- sub('.*\\-', '', names(args))
-
   name <- args$name
-
   if (is.null(name)) {
     name <- paste0("saved", "_", gsub("[ _:]", "-", substr(as.POSIXct(Sys.time()), 1, 19)))
   }
-
   tags <- args$tags
   if(!is.null(tags)){
     if(length(tags) == 1){
       tags <- list(tags)
     }
   }
-
   element_params <- list(element,
                          name = name,
                          description = args$description,
@@ -78,9 +76,16 @@ modalFunction_saveFile <- function(...) {
                          tags = tags,
                          category = args$category)
 
-  # run dsviz(), fringe(), or drop()
-  el <- do.call(elementType, element_params)
+  # add namespace to dsviz(), fringe(), or drop() function
+  element_function_ns <- "dspins::"
+  if(elementType == "fringe") element_function_ns <- "homodatum::"
+
+  element_function <- paste0(element_function_ns, elementType)
+
+  # run dsviz(), fringe(), or drop() with namespace
+  el <- do.call(getfun(element_function), element_params)
 
   # save pin (if org_name is not NULL, saved in org_name, otherwise in user_name)
-  pins <- dspin_urls(element = el, user_name = user_name, org_name = org_name)
+  pins <- dspin_urls(element = el, user_name = user_name, org_name = org_name, bucket_id = bucket_id)
+
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -66,3 +66,14 @@ from_formats_to_module <- function(formats) {
 discard_all_na_cols <- function(d){
   Filter(function(x) !all(is.na(x)), d)
 }
+
+#' Get function from string of namespace::function() to pass to do.call
+getfun <- function(x) {
+  if(length(grep("::", x))>0) {
+    parts <- strsplit(x, "::")[[1]]
+    getExportedValue(parts[1], parts[2])
+  } else {
+    x
+  }
+}
+

--- a/inst/sample-downloadDs.R
+++ b/inst/sample-downloadDs.R
@@ -96,7 +96,7 @@ server <- function(input, output, session) {
     downloadDsServer(id = "download_save_pins",
                      element = reactive(element_dsviz()),
                      formats = c("html", "jpeg", "pdf", "png"),
-                     elementType = "dsviz",
+                     type = "dsviz",
                      user_name = user_name,
                      org_name = org_name)
   })
@@ -107,7 +107,7 @@ server <- function(input, output, session) {
     downloadDsServer(id = "download_0",
                      element = reactive(element_dsviz()),
                      formats = c("html", "jpeg", "pdf", "png"),
-                     elementType = "dsviz",
+                     type = "dsviz",
                      user_name = user_name)
   })
 

--- a/tests/testthat/test-downloadDs.R
+++ b/tests/testthat/test-downloadDs.R
@@ -1,0 +1,25 @@
+test_that("modal save function works", {
+
+  bucket_id <- "testuser"
+  user_name <- "test"
+
+  library(hgchmagic)
+  element <- hgchmagic::hgch_bar_Cat(tibble(a = c("a","b")))
+  name <- "dsmodules test"
+  slug <- dspins::create_slug(name)
+  type <- "dsviz"
+  html_link <- paste0("https://",bucket_id,".dskt.ch/",user_name,"/", slug, "/", slug,".html")
+
+  urls <- modalFunction_saveFile(element = element, type = type, user_name = user_name, bucket_id = bucket_id,
+                                 name = name)
+
+  expect_equal(urls$link, paste0("https://datasketch.co/",user_name,"/", slug))
+  expect_equal(urls$permalink, html_link)
+  expect_equal(urls$iframe_embed, paste0("<iframe src=\"",html_link,"\" frameborder=0 width=\"100%\" height=\"400px\"></iframe>"))
+
+  expect_error(modalFunction_saveFile(type = type, user_name = user_name), "Need element to save.")
+  expect_error(modalFunction_saveFile(element = element, user_name = user_name), "Need type to save file.")
+  expect_error(modalFunction_saveFile(element = element, type = type), "Need user_name or org_name to save file.")
+  expect_error(modalFunction_saveFile(element = element, type = "blah", user_name = user_name), "Element must be of type 'fringe', 'dsviz', or 'drop'.")
+
+})


### PR DESCRIPTION
Fixes to the functionality of `downloadDsServer`:
- Adding error messages to default function used to save file (when `modalFunction = NULL`)
- Add tests to default save function
- Wrap `if(!is.null(url()))` to prevent error while `url()` is being processed 