### PR TITLE
Change back from webshot2 to webshot for downloadimage

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Imports:
     pander,
     knitr,
     rio,
-    webshot2,
+    webshot,
     homodatum (>= 0.1.0),
     shinyinvoer (>= 0.1),
     dspins (>= 0.1.0)

--- a/R/downloadImage.R
+++ b/R/downloadImage.R
@@ -79,7 +79,7 @@ saveInteractive <- function(viz, filename, format = NULL, width = 660, height = 
   if (format == 'html') {
     htmlwidgets::saveWidget(viz, paste0(filename, ".", format))
   } else {
-    webshot2::webshot(tmp, paste0(filename, ".", format), vwidth = width, vheight = height, delay = 0.7)
+    webshot::webshot(tmp, paste0(filename, ".", format), vwidth = width, vheight = height, delay = 0.7)
   }
   file.copy(filename, filename)
 


### PR DESCRIPTION
Using `webshot2` fails to download `png` and `pdf` files when app is deployed. Changing back to `webshot` for which downloads work when apps are displayed.