### PR TITLE
Fix logo dark light theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ vignettes/*.pdf
 .secrets
 .env
 inst/.env
+tests/testthat/.env

--- a/tests/testthat/test-extrahtml.R
+++ b/tests/testthat/test-extrahtml.R
@@ -10,8 +10,8 @@ test_that("google font stylesheet added", {
 
   table_with_font <- import_google_font(viz = table, opts_theme = opts$theme)
 
-  expect_equal(table_with_font$prepend[[2]]$name, "style")
-  expect_equal(table_with_font$prepend[[2]]$children[[1]], "@import url('https://fonts.googleapis.com/css?family=Lato');")
+  expect_equal(table_with_font$prepend[[1]]$name, "style")
+  expect_equal(table_with_font$prepend[[1]]$children[[1]], "@import url('https://fonts.googleapis.com/css?family=Lato');")
 
 
   library(lfltmagic)
@@ -26,13 +26,10 @@ test_that("logo added to reactable", {
   table <- reactable::reactable(data.frame(col1 = c('a', 'b'),
                                            col2 = c(1, 2)))
 
-  opts_theme <- dsvizopts::merge_dsviz_options(branding_include = TRUE)$theme
+  opts_theme <- dsthemer::dsthemer_get(org = "public")
+  opts_theme$logo <- "public"
 
-  opts_theme1 <- dsthemer::dsthemer_get(org = "public")
-
-
-  table_with_logo <- add_logo_reactable(table = table, opts_theme = opts_theme1)
-  table_with_logo
+  table_with_logo <- add_logo_reactable(table = table, opts_theme = opts_theme)
 
   expect_equal(table_with_logo$append[[1]]$name, "img")
   expect_match(table_with_logo$append[[1]]$attribs$src, "^data:image/")


### PR DESCRIPTION
The `logo` parameter of the passed `opts_theme` needs to be the name of the organisation (rather than the path to the logo). Otherwise the logo is automatically chosen in dark theme.