### PR TITLE
Update save publish modal

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,4 +45,5 @@ RoxygenNote: 7.1.1
 Remotes:  
     datasketch/homodatum,
     datasketch/shinyinvoer,
-    datasketch/dspins
+    datasketch/dspins,
+    deepanshu88/shinyCopy2clipboard

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,7 @@ Imports:
     knitr,
     rio,
     webshot,
+    shinyjs,
     homodatum (>= 0.1.0),
     shinyinvoer (>= 0.1),
     dspins (>= 0.1.0)

--- a/R/downloadDs.R
+++ b/R/downloadDs.R
@@ -12,7 +12,7 @@ downloadDsUI <- function(id, text = "Download",
                          modalFullscreen = TRUE,
                          modalTitle = "Save / Publish",
                          modalBody = NULL,
-                         modalBodyInputs = c("name", "description", "sources", "license", "tags", "category"),
+                         modalBodyInputs = c("name", "description", "sources", "license", "tags", "category", "access"),
                          modalButtonLabel = "Submit",
                          modalLinkLabel = "Link",
                          modalFormatChoices = c("HTML" = "html"),
@@ -29,6 +29,8 @@ downloadDsUI <- function(id, text = "Download",
                          categoryLabel = "Category",
                          categoryChoicesLabels = c("No category"),
                          categoryChoicesIDs = c("no-category"),
+                         accessLabel = "Visibility",
+                         accessChoicesLabels = c("Public", "Private"),
                          ...) {
 
   ns <- NS(id)
@@ -110,7 +112,9 @@ downloadDsUI <- function(id, text = "Download",
                                     tagsPlaceholderLabel = tagsPlaceholderLabel,
                                     categoryLabel = categoryLabel,
                                     categoryChoicesLabels = categoryChoicesLabels,
-                                    categoryChoicesIDs = categoryChoicesIDs)
+                                    categoryChoicesIDs = categoryChoicesIDs,
+                                    accessLabel = accessLabel,
+                                    accessChoicesLabels = accessChoicesLabels)
   }
 
 

--- a/R/downloadDs.R
+++ b/R/downloadDs.R
@@ -220,7 +220,7 @@ downloadDsServer <- function(id, formats, errorMessage = NULL, displayLinks = FA
 
     urls <- formServer("modal_form", errorMessage = errorMessage, show_additional_display_on_success = displayLinks, FUN = modalFunction, ...)
 
-    r <- reactiveValues(element_slug = NULL,
+    r <- reactiveValues(element_name = NULL,
                         links = NULL)
 
     # update name field when name was not entered
@@ -232,12 +232,12 @@ downloadDsServer <- function(id, formats, errorMessage = NULL, displayLinks = FA
 
       input_name <- input[[name_field]]
 
-      r$element_slug <- input_name
+      r$element_name <- input_name
 
       if(!is.null(input_name)){
         if(!nzchar(input_name) & !is.null(urls())){
           namePlaceholder <- sub('.*\\/', '', urls()$link)
-          r$element_slug <- namePlaceholder
+          r$element_name <- namePlaceholder
           updateTextInput(session, name_field,
                           value = namePlaceholder)
         }
@@ -246,10 +246,11 @@ downloadDsServer <- function(id, formats, errorMessage = NULL, displayLinks = FA
 
 
     observe({
-      req(r$element_slug)
+      req(r$element_name)
       if(displayLinks){
 
         type <- args$type
+        element_slug <- dspins::create_slug(r$element_name)
 
         formats <- NULL
         if(type == "fringe"){
@@ -262,7 +263,10 @@ downloadDsServer <- function(id, formats, errorMessage = NULL, displayLinks = FA
             formats <- c("html", "png")
         }
 
-        all_links <- dspins::create_ds_links(slug = r$element_slug, folder = args$user_name, formats = formats, element_type = type)
+        folder <- args$org_name
+        if(is.null(folder)) folder <- args$user_name
+
+        all_links <- dspins::create_ds_links(slug = element_slug, folder = folder, formats = formats, element_type = type)
 
         links_share_selected <- all_links$share[[input$`tab-formats`]]
 

--- a/R/downloadDs.R
+++ b/R/downloadDs.R
@@ -6,6 +6,7 @@ downloadDsUI <- function(id, text = "Download",
                          dropdownLabel = "Download",
                          dropdownWidth = 150,
                          getLinkLabel = "Save / Publish",
+                         vertical_line_after = NULL,
                          modalFullscreen = TRUE,
                          modalTitle = "Save / Publish",
                          modalBody = NULL,
@@ -86,20 +87,21 @@ downloadDsUI <- function(id, text = "Download",
 
   modal_content <- div(singleton(tags$head(tags$style(HTML(tab_styles)))),
                        style = "display: flex; justify-content: center; padding: 2rem 4rem;",
-                       div(style = "margin: -20px 0;",
-                           formUI(ns("modal_form"), "", button_label = modalButtonLabel, input_list = modalBody)),
-                       div(style = "background-color: #eee; margin: 0rem 3rem; width: 1px;"),
-                       div(style = "width: 340px;",
-                           div(class = "form-group",
-                               tags$label(class = "control-label", modalLinkLabel),
-                               uiOutput(ns("link"), class = "form-control", style = "min-height: 27px; overflow-x: auto;")),
-                           radioButtons(ns("tab-formats"), "", modalFormatChoices),
-                           div(class = "form-group",
-                               tags$label(class = "control-label", modalPermalinkLabel),
-                               uiOutput(ns("permalink"), class = "form-control", style = "min-height: 27px; overflow-x: auto;")),
-                           div(class = "form-group",
-                               tags$label(class = "control-label", modalIframeLabel),
-                               uiOutput(ns("iframe"), class = "form-control", style = "min-height: 173px; overflow-x: auto;"))))
+                       div(formUI(ns("modal_form"), "", button_label = modalButtonLabel, input_list = modalBody, vertical_line_after = vertical_line_after)))
+
+  # ,
+  # div(style = "background-color: #eee; margin: 0rem 3rem; width: 1px;"),
+  # div(style = "width: 340px;",
+  #     div(class = "form-group",
+  #         tags$label(class = "control-label", modalLinkLabel),
+  #         uiOutput(ns("link"), class = "form-control", style = "min-height: 27px; overflow-x: auto;")),
+  #     radioButtons(ns("tab-formats"), "", modalFormatChoices),
+  #     div(class = "form-group",
+  #         tags$label(class = "control-label", modalPermalinkLabel),
+  #         uiOutput(ns("permalink"), class = "form-control", style = "min-height: 27px; overflow-x: auto;")),
+  #     div(class = "form-group",
+  #         tags$label(class = "control-label", modalIframeLabel),
+  #         uiOutput(ns("iframe"), class = "form-control", style = "min-height: 173px; overflow-x: auto;")))
 
   md <- shinypanels::modal(id = paste0("md-", ns("get_link")), title = modalTitle, modal_content) # provisional, fullscreen = modalFullscreen)
 

--- a/R/downloadDs.R
+++ b/R/downloadDs.R
@@ -123,17 +123,42 @@ downloadDsUI <- function(id, text = "Download",
     if(is.null(displayLinksBody)){
 
       displayLinksBody <- div(div(style = "border-left: 1px solid #eee; height: 300px; position: absolute; top: 25%;"),
-                             div(style = "margin-left: 25px;",
-                                 div(class = "form-group",
-                                     tags$label(class = "control-label", modalLinkLabel),
-                                     uiOutput(ns("link"), class = "form-control", style = "min-height: 27px; overflow-x: auto;")),
-                                 radioButtons(ns("tab-formats"), "", modalFormatChoices),
-                                 div(class = "form-group",
-                                     tags$label(class = "control-label", modalPermalinkLabel),
-                                     uiOutput(ns("permalink"), class = "form-control", style = "min-height: 27px; overflow-x: auto;")),
-                                 div(class = "form-group",
-                                     tags$label(class = "control-label", modalIframeLabel),
-                                     uiOutput(ns("iframe"), class = "form-control", style = "min-height: 100px; overflow-x: auto;"))))
+                              div(style = "margin-left: 25px;",
+                                  div(class = "form-group",
+                                      tags$label(class = "control-label", modalLinkLabel),
+                                      div(uiOutput(ns("link"),
+                                                   class = "form-control",
+                                                   style = "min-height: 27px; overflow-x: auto; width: 80% !important; float: left;"),
+                                          shinyCopy2clipboard::CopyButton(
+                                            "copybtn_link",
+                                            label = "",
+                                            icon = icon("copy"),
+                                            text = "No Text Found"
+                                          ))),
+                                  radioButtons(ns("tab-formats"), "", modalFormatChoices),
+                                  div(class = "form-group",
+                                      tags$label(class = "control-label", modalPermalinkLabel),
+                                      div(
+                                        uiOutput(ns("permalink"),
+                                                 class = "form-control",
+                                                 style = "min-height: 27px; overflow-x: auto; width: 80% !important; float: left;"),
+                                        shinyCopy2clipboard::CopyButton(
+                                          "copybtn_permalink",
+                                          label = "",
+                                          icon = icon("copy"),
+                                          text = "No Text Found"
+                                        ))),
+                                  div(class = "form-group",
+                                      tags$label(class = "control-label", modalIframeLabel),
+                                      div(uiOutput(ns("iframe"),
+                                                   class = "form-control",
+                                                   style = "min-height: 100px; overflow-x: auto; width: 80% !important; float: left;"),
+                                          shinyCopy2clipboard::CopyButton(
+                                            "copybtn_iframe",
+                                            label = "",
+                                            icon = icon("copy"),
+                                            text = "No Text Found"
+                                          )))))
 
     }
 
@@ -240,17 +265,17 @@ downloadDsServer <- function(id, formats, errorMessage = NULL, displayLinks = FA
     # populate link, permalink and iframe fields after saving
     output$link <- renderUI({"link"
       req(r$links)
-      r$links$share[[input$`tab-formats`]]$link
+      text <- r$links$share[[input$`tab-formats`]]$link
       })
 
     output$permalink <- renderUI({"permalink"
       req(r$links)
-      r$links$share[[input$`tab-formats`]]$permalink
+      text <- r$links$share[[input$`tab-formats`]]$permalink
     })
 
     output$iframe <- renderUI({"iframe"
       req(r$links)
-      r$links$share[[input$`tab-formats`]]$embed
+      text <- r$links$share[[input$`tab-formats`]]$embed
       })
 
     element <- eval_reactives(element)

--- a/R/downloadDs.R
+++ b/R/downloadDs.R
@@ -174,7 +174,7 @@ downloadDsUI <- function(id, text = "Download",
 }
 
 #' @export
-downloadDsServer <- function(id, formats, errorMessage = NULL, displayLinks = TRUE, modalFunction = NULL, ...) {
+downloadDsServer <- function(id, formats, errorMessage = NULL, displayLinks = FALSE, modalFunction = NULL, ...) {
 
   args <- list(...)
   element <- args$element

--- a/R/downloadDs.R
+++ b/R/downloadDs.R
@@ -143,7 +143,7 @@ downloadDsUI <- function(id, text = "Download",
   modal_content <- div(singleton(tags$head(tags$style(HTML(tab_styles)))),
                        # style = "display: flex; justify-content: center; padding: 2rem 4rem;",
                        div(formUI(ns("modal_form"), "", button_label = modalButtonLabel, input_list = modalBody, max_inputs_first_column = max_inputs_first_column,
-                                  on_success_body = displayLinksBody)))
+                                  additional_display_body = displayLinksBody)))
 
   md <- shinypanels::modal(id = paste0("md-", ns("get_link")), title = modalTitle, modal_content) # provisional, fullscreen = modalFullscreen)
 

--- a/R/downloadDs.R
+++ b/R/downloadDs.R
@@ -6,7 +6,7 @@ downloadDsUI <- function(id, text = "Download",
                          dropdownLabel = "Download",
                          dropdownWidth = 150,
                          getLinkLabel = "Save / Publish",
-                         vertical_line_after = NULL,
+                         max_inputs_first_column = NULL,
                          displayLinks = TRUE,
                          displayLinksBody = NULL,
                          modalFullscreen = TRUE,
@@ -142,7 +142,7 @@ downloadDsUI <- function(id, text = "Download",
 
   modal_content <- div(singleton(tags$head(tags$style(HTML(tab_styles)))),
                        # style = "display: flex; justify-content: center; padding: 2rem 4rem;",
-                       div(formUI(ns("modal_form"), "", button_label = modalButtonLabel, input_list = modalBody, vertical_line_after = vertical_line_after,
+                       div(formUI(ns("modal_form"), "", button_label = modalButtonLabel, input_list = modalBody, max_inputs_first_column = max_inputs_first_column,
                                   on_success_body = displayLinksBody)))
 
   md <- shinypanels::modal(id = paste0("md-", ns("get_link")), title = modalTitle, modal_content) # provisional, fullscreen = modalFullscreen)

--- a/R/downloadDs.R
+++ b/R/downloadDs.R
@@ -240,17 +240,17 @@ downloadDsServer <- function(id, formats, errorMessage = NULL, displayLinks = FA
     # populate link, permalink and iframe fields after saving
     output$link <- renderUI({"link"
       req(r$links)
-      links$share[[input$`tab-formats`]]$link
+      r$links$share[[input$`tab-formats`]]$link
       })
 
     output$permalink <- renderUI({"permalink"
       req(r$links)
-      links$share[[input$`tab-formats`]]$permalink
+      r$links$share[[input$`tab-formats`]]$permalink
     })
 
     output$iframe <- renderUI({"iframe"
       req(r$links)
-      links$share[[input$`tab-formats`]]$embed
+      r$links$share[[input$`tab-formats`]]$embed
       })
 
     element <- eval_reactives(element)

--- a/R/form.R
+++ b/R/form.R
@@ -1,5 +1,5 @@
 #' @export
-formUI <- function(id, label, button_label = "Submit", input_list = NULL, vertical_line_after = NULL, on_success_body = "") {
+formUI <- function(id, label, button_label = "Submit", input_list = NULL, max_inputs_first_column = NULL, on_success_body = "") {
 
   ns <- shiny::NS(id)
   addResourcePath(prefix = "downloadInfo", directoryPath = system.file("js", package = "dsmodules"))
@@ -23,9 +23,9 @@ formUI <- function(id, label, button_label = "Submit", input_list = NULL, vertic
                 style = "display: flex; flex-direction: column; justify-content: flex-start;",
                 tagList(input_ns))
 
-  if(!is.null(vertical_line_after)){
-    inputs_left <- input_ns[1:vertical_line_after]
-    inputs_right <- input_ns[vertical_line_after + 1 : length(input_ns)]
+  if(!is.null(max_inputs_first_column)){
+    inputs_left <- input_ns[1:max_inputs_first_column]
+    inputs_right <- input_ns[max_inputs_first_column + 1 : length(input_ns)]
 
     inputs <- div(class = "flex-container",
                   style = "display: flex; flex-direction: row; justify-content: space-between;",

--- a/R/form.R
+++ b/R/form.R
@@ -1,5 +1,5 @@
 #' @export
-formUI <- function(id, label, button_label = "Submit", input_list = NULL) {
+formUI <- function(id, label, button_label = "Submit", input_list = NULL, vertical_line_after = NULL) {
 
   ns <- shiny::NS(id)
   addResourcePath(prefix = "downloadInfo", directoryPath = system.file("js", package = "dsmodules"))
@@ -19,13 +19,34 @@ formUI <- function(id, label, button_label = "Submit", input_list = NULL) {
 
   input_ns <- lapply(input_list, updateInputNS, ns)
 
+  inputs <- div(class = "flex-container",
+                style = "display: flex; flex-direction: column; justify-content: flex-start;",
+                tagList(input_ns))
+
+  form_width <- "450px"
+
+  if(!is.null(vertical_line_after)){
+    inputs_left <- input_ns[1:vertical_line_after]
+    inputs_right <- input_ns[vertical_line_after + 1 : length(input_ns)]
+
+    inputs <- div(class = "flex-container",
+                  style = "display: flex; flex-direction: row; justify-content: space-between;",
+                  div(class = "flex-left",
+                      style = "width: 45%;",
+                      tagList(inputs_left)),
+                  div(class = "flex-right",
+                      style = "width: 45%;",
+                      tagList(inputs_right)))
+
+    form_width <- "650px"
+  }
+
   div(class = "formUI",
     tags$label(label, class = "control-label-formUI",
                style = "font-weight:500; color: #435b69; margin-bottom: 10px;"),
     div(style = "display: flex; justify-content: center;  margin: 20px 0;",
-        div(style = "display: flex; flex-direction: column; justify-content: space-between; width: 450px;",
-            div(style = "display: flex; flex-direction: column; justify-content: flex-start;",
-                tagList(input_ns)),
+        div(style = paste0("display: flex; flex-direction: column; justify-content: space-between; width: ",form_width,";"),
+            inputs,
             bt
         )
     )
@@ -87,6 +108,9 @@ formServer <- function(id, errorMessage = NULL, FUN, ...) {
 
 updateInputNS <- function(x, ns){
 
+  if(!is.null(x$attribs$class)){
+    if(x$attribs$class == "layout_item") return(x)
+  }
 
   if("shiny.tag.list" %in% class(x)){
     # chipsInput

--- a/R/form.R
+++ b/R/form.R
@@ -1,5 +1,5 @@
 #' @export
-formUI <- function(id, label, button_label = "Submit", input_list = NULL, max_inputs_first_column = NULL, on_success_body = "") {
+formUI <- function(id, label, button_label = "Submit", input_list = NULL, max_inputs_first_column = NULL, additional_display_body = "") {
 
   ns <- shiny::NS(id)
   addResourcePath(prefix = "downloadInfo", directoryPath = system.file("js", package = "dsmodules"))
@@ -54,7 +54,7 @@ formUI <- function(id, label, button_label = "Submit", input_list = NULL, max_in
     div(id="additional_display",
         class="additional_display_before_success",
         # style="display: none;",
-        on_success_body
+        additional_display_body
     ))
 
 }

--- a/R/form.R
+++ b/R/form.R
@@ -120,9 +120,10 @@ formServer <- function(id, errorMessage = NULL, show_additional_display_on_succe
 
 
 updateInputNS <- function(x, ns){
-
   if(identical(x$attribs$role, "radiogroup")){
     x$attribs$id <- ns(x$attribs$id)
+    x$children[[2]]$children[[1]][[1]]$children[[1]]$attribs$name <- ns(x$children[[2]]$children[[1]][[1]]$children[[1]]$attribs$name)
+    x$children[[2]]$children[[1]][[2]]$children[[1]]$attribs$name <- ns(x$children[[2]]$children[[1]][[2]]$children[[1]]$attribs$name)
     return(x)
   }
 

--- a/R/form.R
+++ b/R/form.R
@@ -121,8 +121,9 @@ formServer <- function(id, errorMessage = NULL, show_additional_display_on_succe
 
 updateInputNS <- function(x, ns){
 
-  if(!is.null(x$attribs$class)){
-    if(x$attribs$class == "layout_item") return(x)
+  if(identical(x$attribs$role, "radiogroup")){
+    x$attribs$id <- ns(x$attribs$id)
+    return(x)
   }
 
   if("shiny.tag.list" %in% class(x)){

--- a/R/saveFile.R
+++ b/R/saveFile.R
@@ -10,7 +10,9 @@ modalBody_saveFile <- function(id,
                                tagsPlaceholderLabel = "Type tag(s) and press enter after each one",
                                categoryLabel = "Category",
                                categoryChoicesLabels = c("No category"),
-                               categoryChoicesIDs = c("no-category")){
+                               categoryChoicesIDs = c("no-category"),
+                               accessLabel = "Visibility",
+                               accessChoicesLabels = c("Public", "Private")){
 
   ns <- NS(id)
 
@@ -22,13 +24,18 @@ modalBody_saveFile <- function(id,
 
   names(categoryChoicesIDs) <- categoryChoicesLabels
 
+  accessChoicesIDs <- c("public", "private")
+  names(accessChoicesIDs) <- accessChoicesLabels
+
   input_options <- list(name = textInput(ns("name"), nameLabel),
                         description = textInput(ns("description"), descriptionLabel),
                         source_title = textInput(ns("source_title"), sourceLabel, value = "", placeholder = sourceTitleLabel),
                         source_path = textInput(ns("source_path"), " ", value = "", placeholder = sourcePathLabel),
                         license = selectInput(ns("license"), licenseLabel, choices = c("CC0", "CC-BY")),
                         tags = shinyinvoer::chipsInput(inputId = ns("tags"), label = tagsLabel, placeholder = tagsPlaceholderLabel),
-                        category = selectizeInput(ns("category"), categoryLabel, choices = categoryChoicesIDs))
+                        category = selectizeInput(ns("category"), categoryLabel, choices = categoryChoicesIDs),
+                        access = radioButtons(ns("access"), label = accessLabel, choices = accessChoicesIDs, selected = "public", inline = TRUE)
+                        )
 
   input_options[filter_by]
 }
@@ -67,6 +74,7 @@ modalFunction_saveFile <- function(...) {
       tags <- list(tags)
     }
   }
+  browser()
   element_params <- list(element,
                          name = name,
                          description = args$description,
@@ -74,7 +82,8 @@ modalFunction_saveFile <- function(...) {
                                              path = args$source_path)),
                          license = args$license,
                          tags = tags,
-                         category = args$category)
+                         category = args$category,
+                         access = args$access)
 
   # add namespace to dsviz(), fringe(), or drop() function
   element_function_ns <- "dspins::"

--- a/R/saveFile.R
+++ b/R/saveFile.R
@@ -74,7 +74,7 @@ modalFunction_saveFile <- function(...) {
       tags <- list(tags)
     }
   }
-  browser()
+
   element_params <- list(element,
                          name = name,
                          description = args$description,

--- a/inst/sample-downloadDs.R
+++ b/inst/sample-downloadDs.R
@@ -75,6 +75,7 @@ server <- function(input, output, session) {
     downloadDsUI("download_save_pins",
                  display = "buttons",
                  modalFormatChoices = c("HTML" = "html", "PNG" = "png"),
+                 vertical_line_after = 4,
                  dropdownLabel = "Download",
                  formats = c("html", "jpeg", "pdf", "png"))
 

--- a/inst/sample-downloadDs.R
+++ b/inst/sample-downloadDs.R
@@ -10,7 +10,8 @@ user_name <- "brandon"
 org_name <- "test"
 
 
-ui <- panelsPage(panel(title = "Examples",
+ui <- panelsPage(shinyjs::useShinyjs(),
+                 panel(title = "Examples",
                        body = div(h3("Ds download module"),
                                   h4("Rendered both from server and from ui"),
                                   br(),

--- a/inst/sample-downloadDs.R
+++ b/inst/sample-downloadDs.R
@@ -49,9 +49,9 @@ server <- function(input, output, session) {
   })
 
   # function to be passed to modalFunction (alternative to using default modalFunction)
-  dspin_urls_ <- function(x, user_name, ...) {
-    x <- eval_reactives(x)
-    f <- fringe(x)
+  dspin_urls_ <- function(element, user_name, ...) {
+    element <- eval_reactives(element)
+    f <- fringe(element)
     dspins_user_board_connect(user_name)
     Sys.setlocale(locale = "en_US.UTF-8")
     dspin_urls(element = f, user_name = user_name)
@@ -89,7 +89,7 @@ server <- function(input, output, session) {
                      element = reactive(element_fringe()),
                      formats = c("csv", "xlsx", "json"),
                      errorMessage = "some error message",
-                     modalFunction = dspin_urls_, reactive(element_fringe()),
+                     modalFunction = dspin_urls_,
                      user_name = user_name)
   })
 
@@ -98,6 +98,7 @@ server <- function(input, output, session) {
     downloadDsServer(id = "download_save_pins",
                      element = reactive(element_dsviz()),
                      formats = c("html", "jpeg", "pdf", "png"),
+                     displayLinks = TRUE,
                      type = "dsviz",
                      user_name = user_name,
                      org_name = org_name)

--- a/inst/sample-downloadDs.R
+++ b/inst/sample-downloadDs.R
@@ -76,7 +76,7 @@ server <- function(input, output, session) {
     downloadDsUI("download_save_pins",
                  display = "buttons",
                  modalFormatChoices = c("HTML" = "html", "PNG" = "png"),
-                 vertical_line_after = 4,
+                 max_inputs_first_column = 4,
                  dropdownLabel = "Download",
                  formats = c("html", "jpeg", "pdf", "png"))
 

--- a/inst/sample-downloadDs.R
+++ b/inst/sample-downloadDs.R
@@ -11,6 +11,7 @@ org_name <- "test"
 
 
 ui <- panelsPage(shinyjs::useShinyjs(),
+                 shinyCopy2clipboard::use_copy(),
                  panel(title = "Examples",
                        body = div(h3("Ds download module"),
                                   h4("Rendered both from server and from ui"),


### PR DESCRIPTION
Closes #72 
Closes #101 
Closes #75 
Closes #74 

Adding functionality to `formUI` / `formServer`:
- using the new parameter `max_inputs_first_column` in `formUI` once can create a form that consists of two columns, separated after inputs `1:max_inputs_first_column`. The `max_inputs_first_column` parameter is `NULL` by default in which case all inputs are displayed in one column.
- with the new parameter `show_additional_display_on_success` additional information can be displayed once the function `FUN` has finished successfully (default = `FALSE`). The additional information can be passed to `formUI` by passing a `div` to `additional_display_body` (default = `""`).

Adapting the `Save / Publish` modal:
1. the tab with the links to the visualisation in the users DS profile only appears once the visualisation has been saved successfully
2.  the format toggle (e.g. `html` vs `png`) for displaying the relevant url after saving is now working
3.  the urls can be copied by clicking a `Copy to clipboard` button
4. a `Visibility` input is added (options `private` and `public`) - only plan PRO users can use this option.

Important: For updates 1. and 3. the app ui needs to include `shinyjs::useShinyjs()` and `shinyCopy2clipboard::use_copy()` respectively.