### PR TITLE
Hide visibility input plan basic

### DIFF
--- a/R/downloadDs.R
+++ b/R/downloadDs.R
@@ -1,5 +1,7 @@
 #' @export
-downloadDsUI <- function(id, text = "Download",
+downloadDsUI <- function(id,
+                         plan = "basic",
+                         text = "Download",
                          formats = NULL,
                          class = NULL,
                          display = "dropdown",
@@ -31,6 +33,8 @@ downloadDsUI <- function(id, text = "Download",
                          categoryChoicesIDs = c("no-category"),
                          accessLabel = "Visibility",
                          accessChoicesLabels = c("Public", "Private"),
+                         upgradeButtonLabel = "Upgrade now",
+                         upgradeText = "To use this feature please upgrade to our Pro plan.",
                          ...) {
 
   ns <- NS(id)
@@ -101,6 +105,7 @@ downloadDsUI <- function(id, text = "Download",
   if(is.null(modalBody)){
 
     modalBody <- modalBody_saveFile(id = id,
+                                    plan = plan,
                                     include_inputs = modalBodyInputs,
                                     nameLabel = nameLabel,
                                     descriptionLabel = descriptionLabel,
@@ -114,7 +119,9 @@ downloadDsUI <- function(id, text = "Download",
                                     categoryChoicesLabels = categoryChoicesLabels,
                                     categoryChoicesIDs = categoryChoicesIDs,
                                     accessLabel = accessLabel,
-                                    accessChoicesLabels = accessChoicesLabels)
+                                    accessChoicesLabels = accessChoicesLabels,
+                                    upgradeButtonLabel = upgradeButtonLabel,
+                                    upgradeText = upgradeText)
   }
 
 

--- a/R/form.R
+++ b/R/form.R
@@ -120,32 +120,69 @@ formServer <- function(id, errorMessage = NULL, show_additional_display_on_succe
 
 
 updateInputNS <- function(x, ns){
-  if(identical(x$attribs$role, "radiogroup")){
-    x$attribs$id <- ns(x$attribs$id)
-    x$children[[2]]$children[[1]][[1]]$children[[1]]$attribs$name <- ns(x$children[[2]]$children[[1]][[1]]$children[[1]]$attribs$name)
-    x$children[[2]]$children[[1]][[2]]$children[[1]]$attribs$name <- ns(x$children[[2]]$children[[1]][[2]]$children[[1]]$attribs$name)
-    return(x)
-  }
 
-  if("shiny.tag.list" %in% class(x)){
-    # chipsInput
-    if(x[[2]]$attribs$class == "shinyinvoer-chips-input"){
-      x[[2]]$attribs$id <- ns(x[[2]]$attribs$id)
+  # radiobutton
+  condition <- tryCatch(
+    x$attribs$role,
+    error=function(e) e
+  )
+
+  if(!inherits(condition, "error")){
+    if(identical(condition, "radiogroup")){
+      x$attribs$id <- ns(x$attribs$id)
+      x$children[[2]]$children[[1]][[1]]$children[[1]]$attribs$name <- ns(x$children[[2]]$children[[1]][[1]]$children[[1]]$attribs$name)
+      x$children[[2]]$children[[1]][[2]]$children[[1]]$attribs$name <- ns(x$children[[2]]$children[[1]][[2]]$children[[1]]$attribs$name)
       return(x)
     }
   }
+
+
+  #chipsinput
+  condition <- tryCatch(
+    x[[2]]$attribs$class,
+    error=function(e) e
+  )
+
+  if(!inherits(condition, "error")){
+    if("shiny.tag.list" %in% class(x)){
+      if(identical(condition, "shinyinvoer-chips-input")){
+        x[[2]]$attribs$id <- ns(x[[2]]$attribs$id)
+        return(x)
+      }
+    }
+  }
+
+
   # textInput
-  if(x$children[[2]]$name == "input"){
-    x$children[[2]]$attribs$id <- ns(x$children[[2]]$attribs$id )
-    return(x)
+  condition <- tryCatch(
+    x$children[[2]]$name,
+    error=function(e) e
+  )
+
+  if(!inherits(condition, "error")){
+    if(identical(condition, "input")){
+      x$children[[2]]$attribs$id <- ns(x$children[[2]]$attribs$id )
+      return(x)
+    }
   }
+
+
   # selectInput
-  if(x$children[[2]]$children[[1]]$name == "select"){
-    x$children[[2]]$children[[1]]$attribs$id <- ns(x$children[[2]]$children[[1]]$attribs$id)
-    x$children[[2]]$children[[2]]$attribs$`data-for` <- ns(x$children[[2]]$children[[2]]$attribs$`data-for`)
-    return(x)
+  condition <- tryCatch(
+    x$children[[2]]$children[[1]]$name,
+    error=function(e) e
+  )
+
+  if(!inherits(condition, "error")){
+    if(identical(condition, "select")){
+      x$children[[2]]$children[[1]]$attribs$id <- ns(x$children[[2]]$children[[1]]$attribs$id)
+      x$children[[2]]$children[[2]]$attribs$`data-for` <- ns(x$children[[2]]$children[[2]]$attribs$`data-for`)
+      return(x)
+    }
   }
-  stop("Input unknown to form")
+
+  warning("Input unknown to form")
+  return(x)
 }
 
 

--- a/R/saveFile.R
+++ b/R/saveFile.R
@@ -1,5 +1,6 @@
 modalBody_saveFile <- function(id,
                                include_inputs,
+                               plan = "basic",
                                nameLabel = "Name",
                                descriptionLabel = "Description",
                                sourceLabel = "Source",
@@ -12,7 +13,10 @@ modalBody_saveFile <- function(id,
                                categoryChoicesLabels = c("No category"),
                                categoryChoicesIDs = c("no-category"),
                                accessLabel = "Visibility",
-                               accessChoicesLabels = c("Public", "Private")){
+                               accessChoicesLabels = c("Public", "Private"),
+                               upgradeButtonLabel = "Upgrade now",
+                               upgradeText = "To use this feature please upgrade to our Pro plan."
+                               ){
 
   ns <- NS(id)
 
@@ -27,6 +31,14 @@ modalBody_saveFile <- function(id,
   accessChoicesIDs <- c("public", "private")
   names(accessChoicesIDs) <- accessChoicesLabels
 
+  access <- div(div(class = "control-label", accessLabel),
+                p( style = "margin-bottom: 15px;margin-top: 10px;",
+                   upgradeText),
+                shiny::actionButton(inputId='url_upgrade', label = upgradeButtonLabel,
+                                    onclick ="window.open('https://datasketch.co/dashboard/upgrade', '_blank')"))
+
+  if(!plan == "basic") access <- radioButtons(ns("access"), label = accessLabel, choices = accessChoicesIDs, selected = "public", inline = TRUE)
+
   input_options <- list(name = textInput(ns("name"), nameLabel),
                         description = textInput(ns("description"), descriptionLabel),
                         source_title = textInput(ns("source_title"), sourceLabel, value = "", placeholder = sourceTitleLabel),
@@ -34,7 +46,7 @@ modalBody_saveFile <- function(id,
                         license = selectInput(ns("license"), licenseLabel, choices = c("CC0", "CC-BY")),
                         tags = shinyinvoer::chipsInput(inputId = ns("tags"), label = tagsLabel, placeholder = tagsPlaceholderLabel),
                         category = selectizeInput(ns("category"), categoryLabel, choices = categoryChoicesIDs),
-                        access = radioButtons(ns("access"), label = accessLabel, choices = accessChoicesIDs, selected = "public", inline = TRUE)
+                        access = access
                         )
 
   input_options[filter_by]
@@ -75,6 +87,9 @@ modalFunction_saveFile <- function(...) {
     }
   }
 
+  access <- args$access
+  if(is.null(access)) access <- "public"
+
   element_params <- list(element,
                          name = name,
                          description = args$description,
@@ -83,7 +98,7 @@ modalFunction_saveFile <- function(...) {
                          license = args$license,
                          tags = tags,
                          category = args$category,
-                         access = args$access)
+                         access = access)
 
   # add namespace to dsviz(), fringe(), or drop() function
   element_function_ns <- "dspins::"

--- a/inst/sample-downloadDs.R
+++ b/inst/sample-downloadDs.R
@@ -8,6 +8,7 @@ library(hgchmagic)
 
 user_name <- "brandon"
 org_name <- "test"
+plan <- "pro"
 
 
 ui <- panelsPage(shinyjs::useShinyjs(),
@@ -76,6 +77,7 @@ server <- function(input, output, session) {
   output$download_server_default_modal_form <- renderUI({
     downloadDsUI("download_save_pins",
                  display = "buttons",
+                 plan = plan,
                  modalFormatChoices = c("HTML" = "html", "PNG" = "png"),
                  max_inputs_first_column = 4,
                  dropdownLabel = "Download",


### PR DESCRIPTION
Radiobutton to select between Visibility options (`public` or `private`) is only shown if the `plan` parameter is not equal to `basic`. The `plan` parameter needs to be passed to `downloadDsUI` which creates the default modal that pops up when the user clicks on `Save / Publish` (either with or without the option to choose data visibility).

If `plan = "basic'` a message is shown with an update option. 