### PR TITLE
Fix sampleFiles input in tableInput

### DIFF
--- a/R/tableInput.R
+++ b/R/tableInput.R
@@ -154,8 +154,10 @@ tableInputServer <- function(id,
 
         if(all(unlist(lapply(sampleFiles, class)) == "character")){
           file <- as.character(inputDataSample)
+          if(!grepl(".csv", file)) return()
           df <- readr::read_csv(file)
         }else if(all(unlist(lapply(sampleFiles, class)) == "data.frame")){
+          if(!inputDataSample %in% names(sampleFiles)) return()
           df <- sampleFiles[[inputDataSample]]
         }
         else{


### PR DESCRIPTION
Was crashing when the format of `sampleFiles` was changing between between a list of elements of type `file.path` and a list of elements of type `data.frame`.

Fixing this by returning `NULL` if `input$inputDataSample` doesn't contain string `".csv"` (in case of format `file.path`) and if `input$inputDataSample` is not in `names(sampleFiles)` (in case of format `data.frame`).